### PR TITLE
Fix block scripts spacing in templates

### DIFF
--- a/chat/templates/base.html
+++ b/chat/templates/base.html
@@ -8,5 +8,5 @@
     {% block body %}
     {% endblock %}
 </body>
-{% block scripts%}{% endblock %}
+{% block scripts %}{% endblock %}
 </html>

--- a/chat/templates/chat/chat.html
+++ b/chat/templates/chat/chat.html
@@ -6,7 +6,7 @@
     <input id="chat-message-submit" type="button" value="Send"/>
 {% endblock %}
 
-{% block scripts%}
+{% block scripts %}
 <script>
     var wss_protocol = (window.location.protocol == 'https:') ? 'wss://': 'ws://';
     var chatSocket = new WebSocket(


### PR DESCRIPTION
## Summary
- adjust spacing in `{% block scripts %}` in templates

## Testing
- `pytest -q`
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6840690542e483339769e5ffa34c44d4